### PR TITLE
Downgrade repo requirements from PHP 8.1 to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"keywords": ["Slim Framework", "access log", "audit log", "accounting"],
 	"readme": "./README.md",
 	"require": {
-		"php": ">=8.1",
+		"php": ">=8.0",
 		"ext-json": "*",
 		"ext-pdo": "*",
         "slim/psr7": "^1.5",


### PR DESCRIPTION
## What changed?
PHP 8.1 was replaced with a PHP 8.0 dependency

## Why are the changes needed?
We've decided to do the PHP 8 upgrade to .0 instead of 8.1 due to outstanding issues with PHP 8.1 in the Connect application.

## How can other developers test the changes?
Testing is ongoing through the deployment process.

## Relevant Links
- Jira ticket: https://medicomhealth.atlassian.net/browse/COL-272


- [ ] All Changes Tested - In progress
- [ ] All Ticket Requirements Met
- [x] Documentation Added/Updated
- [ ] Automated Tests Added/Updated
